### PR TITLE
Add files via upload

### DIFF
--- a/modinfo.json
+++ b/modinfo.json
@@ -1,0 +1,49 @@
+[
+  {
+    "type": "MOD_INFO",
+    "ident": "Mundane_Zombies",
+    "name": "Mundane Zombies",
+    "authors": [ "daftfad", "KantoJolto" ],
+    "description": "Removes all special zombies from the game. This has been updated by KantoJolto to include new enemies. Original mod author remains daftfad.",
+    "category": "monster_exclude",
+    "dependencies": [ "dda" ]
+  },
+  {
+    "type": "MONSTER_BLACKLIST",
+    "monsters": [
+      "mon_boomer",
+      "mon_boomer_huge",
+      "mon_boomer_fungus",
+      "mon_zombie_tough",
+      "mon_zombie_brute",
+      "mon_zombie_hulk",
+      "mon_zombie_grenadier",
+      "mon_zombie_grenadier_elite",
+      "mon_zombie_runner",
+      "mon_zombie_predator",
+      "mon_zombie_hunter",
+      "mon_zombie_hollow",
+      "mon_zombie_armored",
+      "mon_zombie_rot",
+      "mon_zombie_smoker",
+      "mon_zombie_shady",
+      "mon_zombie_gasbag",
+      "mon_zombie_shrieker",
+      "mon_zombie_screecher",
+      "mon_zombie_spitter",
+      "mon_zombie_corrosive",
+      "mon_zombie_acidic",
+      "mon_zombie_electric",
+      "mon_zombie_brute_shocker",
+      "mon_zombie_necro",
+      "mon_zombie_master",
+      "mon_zombie_grabber",
+      "mon_zombie_grappler",
+      "mon_zombie_swimmer",
+	  "mon_zombie_brute_ninja",
+	  "mon_zombie_brute_grappler",
+	  "mon_zombie_biter",
+	  "mon_zombie_mancroc"
+    ]
+  }
+]


### PR DESCRIPTION
Added the mod file for Mundane Zombies. I updated the original obsoleted mod to include the new monsters that weren't already in. They are the zombie biter, zombie mancroc, and the zombie brute ninja and zombie brute grappler. I did not add in the variants of the zombie child so things like sproglodytes and snotgobblers will still exist. If someone feels these need to be removed as well for the sake of thoroughness, let me know and I will update the mod appropriately. The mod is no longer flagged obsolete and can be used at your discretion.

Smoky Bear was removed from the exclusion list because there are no other zombie animals listed in the mod, and if this was intended to be one of the joke monsters [literally an undead "smoky the bear" reference] then it would be more appropriately placed in the Crazy Cataclysm mod.

Mundane Zombies now focuses exclusively on removing any mutated humanoid zombies, leaving only the John Romero-style [but World War Z speed] shamblers.